### PR TITLE
Modify coffee-script installation for promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install
 -------
 
     % npm install hubot-rss-reader -save
-
+    % npm install coffee-script@">=1.8.0" -save
 
 ### edit `external-script.json`
 


### PR DESCRIPTION
日本語で失礼します。便利に使わせてもらっています。

READMEのインストール手順そのままでは動かなかったので、PRしました。
原因は、最新のhubot(2.9.3)ですら、依存しているcoffee-scriptのバージョンが古く(1.6.3)Promiseの記法が使えないからのようです。(参考: https://github.com/github/hubot/blob/master/package.json )
具体的な症状は #19 と同様のエラーが出て動かないというものでしたが、別途 coffe-script の1.8.0を入れると動くことを確認しました。
