### PR TITLE
Set User Agent to a value that Facebook accepts

### DIFF
--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -51,6 +51,8 @@ module.exports = class RSSChecker extends events.EventEmitter
       req = request
         uri: args.url
         timeout: 10000
+        headers:
+          'User-Agent': 'Mozilla/5.0 (Hubot) AppleWebKit/537.36 (KHTML, like Gecko) Hubot'
 
       req.on 'error', (err) ->
         reject err


### PR DESCRIPTION
Facebook will decline serving pages to a browser that does not match some secret list of regexes. This unfortunately includes RSS feeds.