### PR TITLE
Decode XML entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "debug": "*",
     "feedparser": "*",
     "find-rss": "*",
+    "html-entities": "*",
     "hubot-scripts": "*",
     "lodash": "*",
     "request": "*"

--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -19,6 +19,8 @@ debug      = require('debug')('hubot-rss-reader')
 Promise    = require 'bluebird'
 RSSChecker = require path.join __dirname, '../libs/rss-checker'
 FindRSS    = Promise.promisify require 'find-rss'
+Entities   = require 'html-entities'
+entities   = new Entities.XmlEntities()
 
 ## config
 process.env.HUBOT_RSS_INTERVAL ||= 60*10  # 10 minutes
@@ -77,7 +79,8 @@ module.exports = (robot) ->
       if room isnt entry.args.room and
          _.include feeds, entry.feed.url
         logger.info "#{entry.title} #{entry.url} => #{room}"
-        send {room: room}, entry.toString()
+        message = entities.decode entry.toString()
+        send {room: room}, message
 
   checker.on 'error', (err) ->
     logger.error err
@@ -101,7 +104,8 @@ module.exports = (robot) ->
       checker.fetch {url: url, room: msg.message.room}
     .then (entries) ->
       for entry in entries.splice(0,5)
-        send {room: msg.message.room}, entry.toString()
+        message = entities.decode entry.toString()
+        send {room: msg.message.room}, message
       if entries.length > 0
         send {room: msg.message.room},
         "#{process.env.HUBOT_RSS_HEADER} #{entries.length} entries has been omitted"


### PR DESCRIPTION
Facebook feeds replace all diacritics outside of Latin 1 range with numerical entities. This pull request tries to fix it by implementing a workaround that replaces all entities with their corresponding characters.

I am however not sure hubot-rss-reader is the correct level to fix this. It feels like feedparser should be taking care of these (to make sure entries are not double-decoded in the rare case where they actually quote HTML/XML).