### PR TITLE
Add config option for printing summaries

### DIFF
--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -79,7 +79,7 @@ module.exports = class RSSChecker extends events.EventEmitter
             title: entities.decode(feedparser.meta.title or '')
           toString: ->
             s = "#{process.env.HUBOT_RSS_HEADER} #{@title} - [#{@feed.title}]\n#{@url}"
-            s += "\n#{@summary}" if @summary?.length > 0
+            s += "\n#{@summary}" if process.env.HUBOT_RSS_PRINTSUMMARY == "true" && @summary?.length > 0
             return s
           args: args
 

--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -22,9 +22,10 @@ FindRSS    = Promise.promisify require 'find-rss'
 
 ## config
 package_json = require path.join __dirname, '../package.json'
-process.env.HUBOT_RSS_INTERVAL  ||= 60*10  # 10 minutes
-process.env.HUBOT_RSS_HEADER    ||= ':sushi:'
-process.env.HUBOT_RSS_USERAGENT ||= "hubot-rss-reader/#{package_json.version}"
+process.env.HUBOT_RSS_INTERVAL     ||= 60*10  # 10 minutes
+process.env.HUBOT_RSS_HEADER       ||= ':sushi:'
+process.env.HUBOT_RSS_USERAGENT    ||= "hubot-rss-reader/#{package_json.version}"
+process.env.HUBOT_RSS_PRINTSUMMARY ||= "false"
 
 module.exports = (robot) ->
 


### PR DESCRIPTION
Just added a feed to our channel with this script and experienced immediate channel flooding. I think by default it's nicer to not show the summary, so I added a config flag to make it optional.