### PR TITLE
Color support for IRC channels

### DIFF
--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -16,6 +16,7 @@ async      = require 'async'
 debug      = require('debug')('hubot-rss-reader:rss-checker')
 cheerio    = require 'cheerio'
 Promise    = require 'bluebird'
+c          = require 'irc-colors'
 
 module.exports = class RSSChecker extends events.EventEmitter
   constructor: (@robot) ->
@@ -78,7 +79,11 @@ module.exports = class RSSChecker extends events.EventEmitter
             url: args.url
             title: entities.decode(feedparser.meta.title or '')
           toString: ->
-            s = "#{process.env.HUBOT_RSS_HEADER} #{@title} - [#{@feed.title}]\n#{@url}"
+            if process.env.HUBOT_RSS_IRCCOLORS is "true"
+              s = "#{c.pink(process.env.HUBOT_RSS_HEADER)} #{@title} #{c.purple('- ['+@feed.title+']')}\n#{c.lightgrey.underline(@url)}"
+            else
+              s = "#{process.env.HUBOT_RSS_HEADER} #{@title} - [#{@feed.title}]\n#{@url}"
+
             if process.env.HUBOT_RSS_PRINTSUMMARY is "true" and @summary?.length > 0
               s += "\n#{@summary}"
             return s

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "find-rss": "*",
     "html-entities": "*",
     "hubot-scripts": "*",
+    "irc-colors": "^1.1.1",
     "lodash": "*",
     "request": "*"
   },


### PR DESCRIPTION
I added the new config flag `HUBOT_RSS_IRCCOLORS` (false by default). If it's set, IRC messages will use colors so that the messages are easier to parse for human brains. The color support itself is implemented using the [irc-colors](https://github.com/fent/irc-colors.js) module.