### PR TITLE
load scripts via index.coffee to support hubot-help

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,12 @@
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (robot, scripts) ->
+  scriptsPath = path.resolve(__dirname, 'scripts')
+  fs.exists scriptsPath, (exists) ->
+    if exists
+      for script in fs.readdirSync(scriptsPath)
+        if scripts? and '*' not in scripts
+          robot.loadFile(scriptsPath, script) if script in scripts
+        else
+          robot.loadFile(scriptsPath, script)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "version": "0.8.1",
   "description": "Hubot RSS Reader",
-  "main": "scripts/hubot-rss-reader.coffee",
+  "main": "index.coffee",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
I added index.coffee to print rss-commands with hubot-help. index.coffee is derived from generator-hubot-script. And its `robot.loadFile()` parses `Commands:` section of scripts.

```
hubot> hubot help
hubot> hubot help - Displays all of the help commands that hubot knows about.
hubot help <query> - Displays all help commands that match <query>.
hubot rss add https://github.com/shokai.atom
hubot rss delete #room_name
hubot rss delete http://shokai.org/blog/feed
hubot rss dump
hubot rss list
```