### PR TITLE
Supports lodash v4.0.0

### DIFF
--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -145,7 +145,7 @@ module.exports = class RSSChecker extends events.EventEmitter
   addFeed: (room, url) ->
     new Promise (resolve, reject) =>
       feeds = @getFeeds room
-      if _.contains feeds, url
+      if _.includes feeds, url
         return reject "#{url} is already registered"
       feeds.push url
       @setFeeds room, feeds.sort()
@@ -154,7 +154,7 @@ module.exports = class RSSChecker extends events.EventEmitter
   deleteFeed: (room, url) ->
     new Promise (resolve, reject) =>
       feeds = @getFeeds room
-      unless _.contains feeds, url
+      unless _.includes feeds, url
         return reject "#{url} is not registered"
       feeds.splice feeds.indexOf(url), 1
       @setFeeds room, feeds

--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -89,7 +89,7 @@ module.exports = (robot) ->
     last_state_is_error[entry.feed.url] = false
     for room, feeds of checker.getAllFeeds()
       if room isnt entry.args.room and
-         _.include feeds, entry.feed.url
+         _.includes feeds, entry.feed.url
         logger.info "#{entry.title} #{entry.url} => #{room}"
         send {room: room}, entry.toString()
 
@@ -101,7 +101,7 @@ module.exports = (robot) ->
       return
     last_state_is_error[err.feed.url] = true
     for room, feeds of checker.getAllFeeds()
-      if _.include feeds, err.feed.url
+      if _.includes feeds, err.feed.url
         send {room: room}, "[ERROR] #{err.feed.url} - #{err.error.message or err.error}"
 
   robot.respond /rss\s+(add|register)\s+(https?:\/\/[^\s]+)$/im, (msg) ->


### PR DESCRIPTION
Some of the alias has been removed in lodash v4.0.0.

https://github.com/lodash/lodash/wiki/Changelog

Since the alias _.include and _.contains has been used, I changed to _.includes.

https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_includescollection-target-fromindex0
