### PR TITLE
Fix startup error caused by operator precedence

### DIFF
--- a/scripts/hubot-rss-reader.coffee
+++ b/scripts/hubot-rss-reader.coffee
@@ -71,7 +71,7 @@ module.exports = (robot) ->
   robot.brain.once 'loaded', ->
     run = (opts) ->
       logger.info "checker start"
-      checker.check opts
+      checker.check(opts)
       .then ->
         logger.info "wait #{process.env.HUBOT_RSS_INTERVAL} seconds"
         setTimeout run, 1000 * process.env.HUBOT_RSS_INTERVAL


### PR DESCRIPTION
The "." operator binds before (implicit) function call, so this was accidentally `opts.then ->` and caused this with most versions of CoffeeScript:

```
[Tue May 09 2017 17:58:05 GMT-0700 (PDT)] ERROR TypeError: Cannot read property 'then' of undefined
  at run (/Users/kylev/OSS/hubot-rss-reader/scripts/hubot-rss-reader.coffee:74:7, <js>:94:34)
  at Brain.<anonymous> (/Users/kylev/OSS/hubot-rss-reader/scripts/hubot-rss-reader.coffee:83:5, <js>:103:14)
  at Brain.g (events.js:273:16)
  at emitOne (events.js:90:13)
  at Brain.emit (events.js:182:7)
  at Brain.mergeData (/Users/kylev/Personal/foo/node_modules/hubot/src/brain.coffee:92:5, <js>:82:19)
  at /Users/kylev/OSS/hubot-redis-brain/src/redis-brain.coffee:49:9, <js>:28:23
  at try_callback (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/index.js:548:9)
  at RedisClient.return_reply (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/index.js:630:13)
  at ReplyParser.<anonymous> (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/index.js:282:14)
  at emitOne (events.js:90:13)
  at ReplyParser.emit (events.js:182:7)
  at ReplyParser.send_reply (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/lib/parser/javascript.js:300:10)
  at ReplyParser.execute (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/lib/parser/javascript.js:203:22)
  at RedisClient.on_data (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/index.js:504:27)
  at Socket.<anonymous> (/Users/kylev/OSS/hubot-redis-brain/node_modules/redis/index.js:82:14)
  at emitOne (events.js:90:13)
  at Socket.emit (events.js:182:7)
  at readableAddChunk (_stream_readable.js:147:16)
  at Socket.Readable.push (_stream_readable.js:111:10)
  at TCP.onread (net.js:523:20)
```