### PR TITLE
require lodash at least 3.0, when _.contains was aliased to _.includes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "html-entities": "*",
     "iconv": "*",
     "irc-colors": "^1.1.1",
-    "lodash": "*",
+    "lodash": ">=3",
     "request": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
I installed broken-link-checker in my hubot, which uses bhttp, which requires `"lodash": "^2.4.1"`.  Since hubot-rss-reader requires `"lodash": "*"`, this resolved to version 2.4.2 of lodash.  Unfortunately `_.includes` was not introduced until lodash 3.0.  

With version 2.4.2 installed, hubot-rss-reader spits out "[ERROR] TypeError: _.includes is not a function".

I changed the package.json to require `"lodash": ">=3".  Now yarn is resolving this to `4.17.4`, and I no longer get the type error.

```
lodash@>=3, lodash@^4.14.0:
  version "4.17.4"
  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
```
