### PR TITLE
add feedurl option to feedparser

### DIFF
--- a/libs/rss-checker.coffee
+++ b/libs/rss-checker.coffee
@@ -53,7 +53,7 @@ module.exports = class RSSChecker extends events.EventEmitter
           args[k] = v
       debug "fetch #{args.url}"
       debug args
-      feedparser = new FeedParser
+      feedparser = new FeedParser {feedurl: args.url}
       req = request
         uri: args.url
         timeout: 10000


### PR DESCRIPTION
Feedparser sometimes fails to resolve relative URLs.
(e.g. [Github's release atom feed](https://github.com/shokai/hubot-rss-reader/releases.atom).
 refer to: [feedparser's issue](https://github.com/danmactough/node-feedparser/issues/168))
Adding `feedurl` option as a workaround of this issue as written in [README](https://github.com/danmactough/node-feedparser#options).